### PR TITLE
Runtime 23.08

### DIFF
--- a/net.zgcoder.skycheckers.json
+++ b/net.zgcoder.skycheckers.json
@@ -33,6 +33,13 @@
 					"type": "archive",
 					"url": "https://github.com/zorgiepoo/Sky-Checkers/releases/download/1.3.1/sc-snap-pak-repo.tgz",
 					"sha256": "b75d1fc7bc76d4147f57055f965fb1d752222beba4dc90115b388af5532b3c87"
+				},
+				{
+					"type": "shell",
+					"commands": [
+						"sed -i -s 's\/-lGLEW\/-I\\\/app\\\/share\\\/include -L\\\/app\\\/lib -lGLEW\/g' linux/Makefile",
+						"mkdir ${FLATPAK_DEST}/bin"
+					]
 				}
 			]
 		},

--- a/net.zgcoder.skycheckers.json
+++ b/net.zgcoder.skycheckers.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "net.zgcoder.skycheckers",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "22.08",
+	"runtime-version": "23.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "skycheckers",
 	"finish-args": [

--- a/net.zgcoder.skycheckers.json
+++ b/net.zgcoder.skycheckers.json
@@ -13,29 +13,6 @@
 		"--device=all"
 	],
 	"modules": [
-		{
-			"name": "SDL2",
-			"buildsystem": "autotools",
-			"config-opts": ["--disable-static"],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "https://www.libsdl.org/release/SDL2-2.28.3.tar.gz",
-					"sha256": "7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518"
-				}
-			],
-			"cleanup": [
-				"/bin/sdl2-config",
-				"/include",
-				"/lib/libSDL2.la",
-				"/lib/libSDL2main.a",
-				"/lib/libSDL2main.la",
-				"/lib/libSDL2_test.a",
-				"/lib/libSDL2_test.la",
-				"/lib/cmake",
-				"/share/aclocal"
-			]
-		},
 		"shared-modules/glu/glu-9.json",
 		"shared-modules/glew/glew.json",
 		{


### PR DESCRIPTION
@zorgiepoo If you can review 🙏🏼


In the Makefile you're copying the game binary to `/app/bin` before creating the directory, it'll fail as nothing creates that directory here. You should create it first.

glew is installed in `/app`, gcc will fail to find it as it searches in `/usr`, you should probably use pkg-config to search for them.

SDL 2 is included in the runtime along with libdecor.